### PR TITLE
feat(exchange): treat various ssl and tcp errors as `AMQPConnectionException`

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -491,12 +491,19 @@ void php_amqp_zend_throw_exception(
             break;
         case AMQP_RESPONSE_LIBRARY_EXCEPTION:
             switch (reply.library_error) {
+                case AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD:
                 case AMQP_STATUS_CONNECTION_CLOSED:
+                case AMQP_STATUS_HOSTNAME_RESOLUTION_FAILED:
                 case AMQP_STATUS_SOCKET_ERROR:
                 case AMQP_STATUS_SOCKET_CLOSED:
                 case AMQP_STATUS_SOCKET_INUSE:
-                case AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD:
-                case AMQP_STATUS_HOSTNAME_RESOLUTION_FAILED:
+                case AMQP_STATUS_SSL_CONNECTION_FAILED:
+                case AMQP_STATUS_SSL_ERROR:
+                case AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED:
+                case AMQP_STATUS_SSL_PEER_VERIFY_FAILED:
+                case AMQP_STATUS_SSL_SET_ENGINE_FAILED:
+                case AMQP_STATUS_SSL_UNIMPLEMENTED:
+                case AMQP_STATUS_TCP_ERROR:
                     exception_ce = amqp_connection_exception_class_entry;
                     break;
                 default:


### PR DESCRIPTION
This tries to fix symfony/symfony/issues/48241

The specific issue is that e.g. the AWS Load Balancer closes idle connections after a certain time. Long running tasks will then run into the issue of a lost connection.
symfony/symfony/pull/54167 already provides an adequate solution by simply trying to reconnect. However, the fix specifically catches `AMQPConnectionException`, while the actual exception thrown is the less specific `AMQPException`.
This can also be seen in the original issue:

> (**AMQPException**): Library error: a SSL error occurred

My first instinct was to catch the less specific Exception instead, which would solve the issue. But I think there is a fair argument to be made, that this indeed is an Exception relating to the connection. That's where this PR is coming from.
I tried coming up with a specific test, but I'm at a loss how to recreate this specific scenario (connection closed by server). Feedback is obviously welcome.

I really hope that helps. Thanks a bunch!

